### PR TITLE
feat: board member management support

### DIFF
--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -222,13 +222,31 @@ Unassign a member from a card:
 python3 scripts/card_unassign.py --board "Launch Planning" --list "Doing" --card "Draft landing page copy" --member "@michael"
 ```
 
+Invite a member to a board:
+
+```bash
+python3 scripts/board_invite.py --board "Launch Planning" --member "user@example.com" --role "normal"
+```
+
+Remove a member from a board:
+
+```bash
+python3 scripts/board_remove_member.py --board "Launch Planning" --member "@michael"
+```
+
+Update a member's role on a board:
+
+```bash
+python3 scripts/board_member_role.py --board "Launch Planning" --member "@michael" --role "admin"
+```
+
 ## Capability summary
 
 | Category | Status |
 | --- | --- |
-| Supported now | boards, lists, cards, comments, attachments, labels, due/start dates, archive/unarchive, member assignment |
+| Supported now | boards, lists, cards, comments, attachments, labels, due/start dates, archive/unarchive, member assignment, board member management |
 | Near-term | checklist support, dedicated start-date helpers, richer read-only history/detail scripts |
-| Intentionally unsupported | delete flows, board admin/invites, webhooks/listeners, local sync state, automation |
+| Intentionally unsupported | delete flows (except board members), webhooks/listeners, local sync state, automation |
 
 ## Action script map
 
@@ -257,6 +275,9 @@ python3 scripts/card_unassign.py --board "Launch Planning" --list "Doing" --card
 - `scripts/board_close.py` — close board
 - `scripts/board_reopen.py` — reopen board
 - `scripts/members_list.py` — list members on a board
+- `scripts/board_invite.py` — invite member to board
+- `scripts/board_remove_member.py` — remove member from board
+- `scripts/board_member_role.py` — update member role on board
 - `scripts/card_assign.py` — assign member to card
 - `scripts/card_unassign.py` — unassign member from card
 
@@ -285,6 +306,9 @@ python3 scripts/card_unassign.py --board "Launch Planning" --list "Doing" --card
 - Unarchive `Draft landing page copy`.
 - Close the `Launch Planning` board.
 - List members on the `Launch Planning` board.
+- Invite `user@example.com` to the `Launch Planning` board.
+- Remove `@michael` from the `Launch Planning` board.
+- Make `@michael` an admin on the `Launch Planning` board.
 - Assign `@michael` to `Draft landing page copy` in `Doing` on `Launch Planning`.
 - Unassign `@michael` from `Draft landing page copy`.
 

--- a/skills/trello/scripts/board_invite.py
+++ b/skills/trello/scripts/board_invite.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import argparse
+from trello_api import TrelloClient, main_guard, print_json
+
+def run():
+    parser = argparse.ArgumentParser(description="Invite a member to a Trello board by email or username.")
+    parser.add_argument("--board", required=True, help="Board ID or name")
+    parser.add_argument("--member", required=True, help="Email address or Trello username (with or without @)")
+    parser.add_argument("--role", choices=["admin", "normal"], default="normal", help="Role for the new member (default: normal)")
+    args = parser.parse_args()
+
+    client = TrelloClient()
+    board = client.resolve_board(args.board)
+    
+    # We pass the member ref directly to add_member_to_board which handles email vs username
+    member_ref = args.member.lstrip("@")
+    result = client.add_member_to_board(board["id"], member_ref, args.role)
+    print_json(result)
+
+if __name__ == "__main__":
+    main_guard(run)

--- a/skills/trello/scripts/board_member_role.py
+++ b/skills/trello/scripts/board_member_role.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import argparse
+from trello_api import TrelloClient, main_guard, print_json
+
+def run():
+    parser = argparse.ArgumentParser(description="Update a member's role on a Trello board.")
+    parser.add_argument("--board", required=True, help="Board ID or name")
+    parser.add_argument("--member", required=True, help="Member ID, username (with or without @), or full name")
+    parser.add_argument("--role", choices=["admin", "normal"], required=True, help="New role for the member")
+    args = parser.parse_args()
+
+    client = TrelloClient()
+    board = client.resolve_board(args.board)
+    member = client.resolve_member(args.member, board["id"])
+    
+    result = client.update_member_role_on_board(board["id"], member["id"], args.role)
+    print_json(result)
+
+if __name__ == "__main__":
+    main_guard(run)

--- a/skills/trello/scripts/board_remove_member.py
+++ b/skills/trello/scripts/board_remove_member.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import argparse
+from trello_api import TrelloClient, main_guard, print_json
+
+def run():
+    parser = argparse.ArgumentParser(description="Remove a member from a Trello board.")
+    parser.add_argument("--board", required=True, help="Board ID or name")
+    parser.add_argument("--member", required=True, help="Member ID, username (with or without @), or full name")
+    args = parser.parse_args()
+
+    client = TrelloClient()
+    board = client.resolve_board(args.board)
+    member = client.resolve_member(args.member, board["id"])
+    
+    result = client.remove_member_from_board(board["id"], member["id"])
+    print_json(result)
+
+if __name__ == "__main__":
+    main_guard(run)

--- a/skills/trello/scripts/trello_api.py
+++ b/skills/trello/scripts/trello_api.py
@@ -175,6 +175,22 @@ class TrelloClient:
     def list_members_on_board(self, board_id: str) -> List[Dict[str, Any]]:
         return self.request("GET", f"/boards/{board_id}/members", params={"fields": "fullName,username,id"})
 
+    def add_member_to_board(self, board_id: str, email_or_username: str, role: str = "normal") -> Dict[str, Any]:
+        # Trello API PUT /1/boards/{id}/members allows adding by email or username
+        # If it's an email, it's passed as 'email'. If it's a username, it's 'idMember' (which also takes usernames)
+        params = {"type": role}
+        if "@" in email_or_username:
+            params["email"] = email_or_username
+            return self.request("PUT", f"/boards/{board_id}/members", params=params)
+        else:
+            return self.request("PUT", f"/boards/{board_id}/members/{email_or_username}", params=params)
+
+    def remove_member_from_board(self, board_id: str, member_id: str) -> Dict[str, Any]:
+        return self.request("DELETE", f"/boards/{board_id}/members/{member_id}")
+
+    def update_member_role_on_board(self, board_id: str, member_id: str, role: str) -> Dict[str, Any]:
+        return self.request("PUT", f"/boards/{board_id}/members/{member_id}", params={"type": role})
+
     def assign_member_to_card(self, card_id: str, member_id: str) -> Dict[str, Any]:
         return self.request("POST", f"/cards/{card_id}/idMembers", params={"value": member_id})
 

--- a/tests/test_trello_board_members.py
+++ b/tests/test_trello_board_members.py
@@ -1,0 +1,111 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "trello" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import board_invite
+import board_remove_member
+import board_member_role
+from trello_api import TrelloClient
+
+class MemberManagementTests(unittest.TestCase):
+    def test_client_add_member_email(self):
+        client = TrelloClient.__new__(TrelloClient)
+        client.key = "k"
+        client.token = "t"
+        with patch.object(client, "request") as mock_request:
+            client.add_member_to_board("b123", "user@example.com", "admin")
+            mock_request.assert_called_once_with(
+                "PUT", "/boards/b123/members", params={"type": "admin", "email": "user@example.com"}
+            )
+
+    def test_client_add_member_username(self):
+        client = TrelloClient.__new__(TrelloClient)
+        client.key = "k"
+        client.token = "t"
+        with patch.object(client, "request") as mock_request:
+            client.add_member_to_board("b123", "jdoe", "normal")
+            mock_request.assert_called_once_with(
+                "PUT", "/boards/b123/members/jdoe", params={"type": "normal"}
+            )
+
+    def test_client_remove_member(self):
+        client = TrelloClient.__new__(TrelloClient)
+        client.key = "k"
+        client.token = "t"
+        with patch.object(client, "request") as mock_request:
+            client.remove_member_from_board("b123", "m123")
+            mock_request.assert_called_once_with("DELETE", "/boards/b123/members/m123")
+
+    def test_client_update_member_role(self):
+        client = TrelloClient.__new__(TrelloClient)
+        client.key = "k"
+        client.token = "t"
+        with patch.object(client, "request") as mock_request:
+            client.update_member_role_on_board("b123", "m123", "admin")
+            mock_request.assert_called_once_with(
+                "PUT", "/boards/b123/members/m123", params={"type": "admin"}
+            )
+
+    def test_invite_cli(self):
+        calls = {}
+        class FakeClient:
+            def resolve_board(self, board):
+                calls["resolve_board"] = board
+                return {"id": "b123"}
+            def add_member_to_board(self, board_id, member, role):
+                calls["add_member"] = (board_id, member, role)
+                return {"id": "m123"}
+
+        with patch("board_invite.TrelloClient", return_value=FakeClient()), \
+             patch.object(sys, "argv", ["board_invite.py", "--board", "B", "--member", "@jdoe", "--role", "admin"]), \
+             patch("sys.stdout", new=io.StringIO()):
+            board_invite.run()
+        
+        self.assertEqual(calls["resolve_board"], "B")
+        self.assertEqual(calls["add_member"], ("b123", "jdoe", "admin"))
+
+    def test_remove_member_cli(self):
+        calls = {}
+        class FakeClient:
+            def resolve_board(self, board):
+                return {"id": "b123"}
+            def resolve_member(self, member, board_id):
+                calls["resolve_member"] = (member, board_id)
+                return {"id": "m123"}
+            def remove_member_from_board(self, board_id, member_id):
+                calls["remove_member"] = (board_id, member_id)
+                return {}
+
+        with patch("board_remove_member.TrelloClient", return_value=FakeClient()), \
+             patch.object(sys, "argv", ["board_remove_member.py", "--board", "B", "--member", "jdoe"]), \
+             patch("sys.stdout", new=io.StringIO()):
+            board_remove_member.run()
+            
+        self.assertEqual(calls["resolve_member"], ("jdoe", "b123"))
+        self.assertEqual(calls["remove_member"], ("b123", "m123"))
+
+    def test_member_role_cli(self):
+        calls = {}
+        class FakeClient:
+            def resolve_board(self, board):
+                return {"id": "b123"}
+            def resolve_member(self, member, board_id):
+                return {"id": "m123"}
+            def update_member_role_on_board(self, board_id, member_id, role):
+                calls["update_role"] = (board_id, member_id, role)
+                return {}
+
+        with patch("board_member_role.TrelloClient", return_value=FakeClient()), \
+             patch.object(sys, "argv", ["board_member_role.py", "--board", "B", "--member", "jdoe", "--role", "admin"]), \
+             patch("sys.stdout", new=io.StringIO()):
+            board_member_role.run()
+            
+        self.assertEqual(calls["update_role"], ("b123", "m123", "admin"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds board-level member management to the Trello skill. Closes #19.

Users can now invite members, remove members, and update member roles on Trello boards directly via the skill.

## Changes

- `scripts/board_invite.py` — invite by email or `@username` with `--role` (admin/normal)
- `scripts/board_remove_member.py` — remove a member from a board
- `scripts/board_member_role.py` — update a member's board role
- `scripts/trello_api.py` — added `add_member_to_board`, `remove_member_from_board`, `update_member_role_on_board`
- `skills/trello/SKILL.md` — updated capability matrix, action script map, and example prompts
- `tests/test_trello_board_members.py` — 7 new tests (all 44 pass)

## CI

- CI (tests): passing
- PR review automation: failing due to missing ANTHROPIC_API_KEY / OPENAI_API_KEY repo secrets — infrastructure gap, not a code issue

## Review

- Cortan: approved
- Spartan: approved (see comment)